### PR TITLE
fix: Moving stacks to the end of the accordion

### DIFF
--- a/AccordionSolitaire/GameScene.cpp
+++ b/AccordionSolitaire/GameScene.cpp
@@ -215,7 +215,7 @@ void GameScene::processMouseMoved(sf::Vector2f mousePos)
 		shaders["Card"]->setUniform("alpha", 0.5f);
 	}
 
-	for (int i = 0; i < game->getRightmostStack(); ++i)
+	for (int i = 0; i <= game->getRightmostStack(); ++i)
 	{
 		if (game->stacks[i].getBaseStackSprite().getGlobalBounds().contains(mousePos))
 		{


### PR DESCRIPTION
The code to calculate what stack is being hovered over stopped at `game->getRightmostStack() - 1` instead of on `game->getRightmostStack()`, causing it to ignore the end of the accordion. Now it includes that position so it all works again